### PR TITLE
server: await cb() in apiWrapper

### DIFF
--- a/server-src/apis.js
+++ b/server-src/apis.js
@@ -55,7 +55,7 @@ async function apiWrapper(req, res, config, apiDesc, cb) {
   let decoded;
   try {
     decoded = await verifyAuth(req, res, config);
-    cb(decoded);
+    await cb(decoded);
   } catch (err) {
     logger.error('%s failure: %s', apiDesc, err);
     if (decoded) { // non-decoded cases get errored out in verifyAuth


### PR DESCRIPTION
Fixes a server crash involving JWT decoding:

```
jwt verify err JsonWebTokenError: jwt must be provided
    at Object.module.exports [as verify] (/Users/mikol/work/com.github/open-climate-tech/checkfire/node_modules/jsonwebtoken/verify.js:53:17)
    at /Users/mikol/work/com.github/open-climate-tech/checkfire/server-src/oct_utils.js:93:9
    at new Promise (<anonymous>)
    at Object.checkAuth (/Users/mikol/work/com.github/open-climate-tech/checkfire/server-src/oct_utils.js:92:10)
    at verifyAuth (/Users/mikol/work/com.github/open-climate-tech/checkfire/server-src/apis.js:44:37)
    at apiWrapper (/Users/mikol/work/com.github/open-climate-tech/checkfire/server-src/apis.js:57:21)
    at /Users/mikol/work/com.github/open-climate-tech/checkfire/server-src/apis.js:233:5
    at Layer.handle [as handle_request] (/Users/mikol/work/com.github/open-climate-tech/checkfire/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/mikol/work/com.github/open-climate-tech/checkfire/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/Users/mikol/work/com.github/open-climate-tech/checkfire/node_modules/express/lib/router/route.js:112:3)
/Users/mikol/work/com.github/open-climate-tech/checkfire/server-src/apis.js:234
      const preferences = await oct_utils.getUserPreferences(db, decoded.email);
                                                                         ^

TypeError: Cannot read property 'email' of undefined
    at /Users/mikol/work/com.github/open-climate-tech/checkfire/server-src/apis.js:234:74
    at apiWrapper (/Users/mikol/work/com.github/open-climate-tech/checkfire/server-src/apis.js:58:5)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

`apiWrapper()` was not awaiting the potentially (and in practice,
guaranteed) async `cb()` callback; any errors thrown by `cb()` would go
uncaught as execution would continue before the async code completed.
The callback in question, `getPreferences`, throws such an uncaught
exception, which crashes the server (because `decoded` is not defined
without a valid JWT).

This change may have broader impact since it seems like many of the API
handlers use assertions as a signal (hence the 400 Bad Request response
issued by `apiWrapper()` when `decoded` is defined). These assertions
likely were not being caught by `apiWrapper()` and so would have also
crashed the server in practice. (It’s worth noting that not all of the
failure modes will be due to a malformed request -- connectivity and db
failures should probably result in 5xx responses, for example.)