### PR TITLE
client: Create hidden route for v2

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -62,9 +62,6 @@
           <a href="/#contact" class="w3-bar-item w3-button w3-padding-large">Contact</a>
       </div>
   </div>
-  <div class="oct-head-margin">
-    &nbsp;
-  </div>
   <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,5 @@
 .App {
+  margin-top: 62.5px;
   text-align: center;
 }
 .w3-tooltip .tooltip-text {

--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,8 @@ import Preferences from './Preferences';
 import LabelImage from './LabelImage';
 import Prototypes from './Prototypes';
 
+import V2 from './v2/App.jsx'
+
 import googleSigninImg from './btn_google_signin_dark_normal_web.png';
 import googleSigninImgFocus from './btn_google_signin_dark_focus_web.png';
 import Cookies from 'js-cookie';
@@ -41,6 +43,17 @@ import jwt_decode from 'jwt-decode'
 import {getServerUrl, Legalese, serverGet} from './OctReactUtils';
 
 const qs = require('qs');
+
+const LEGACY_PATHS = [
+  '/',
+  '/confirmed',
+  '/detected',
+  '/labelImage',
+  '/preferences',
+  '/prototypes',
+  '/selected',
+  '/wildfirecheck'
+]
 
 function FirePagesHeader(props) {
   return (<div>
@@ -132,8 +145,11 @@ class App extends Component {
           {
             (this.state.redirect && <Redirect to={this.state.redirect} />)
           }
-          <FirePagesHeader validCookie={this.state.validCookie} signin={()=> this.signin()}/>
+          <Route path={LEGACY_PATHS} exact>
+            <FirePagesHeader validCookie={this.state.validCookie} signin={()=> this.signin()}/>
+          </Route>
           <Switch>
+            <Route path="/v2/wildfirecheck" exact component={V2} />
             <Route path="/prototypes" exact component={Prototypes} />
             <Route path="/confirmed" exact render={props =>
                     <ConfirmedFires {...props} />} />
@@ -149,10 +165,12 @@ class App extends Component {
                     <VoteFires {...props} validCookie={this.state.validCookie}
                       signin={() => this.signin()} invalidateCookie={() => this.invalidateCookie()} />} />
           </Switch>
+          <Route path={LEGACY_PATHS} exact>
+            <Legalese/>
+          </Route>
         </Router>
-        <Legalese/>
       </div>
-    );  
+    );
   }
 }
 

--- a/src/v2/App.jsx
+++ b/src/v2/App.jsx
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------------
+// Copyright 2020 Open Climate Tech Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+import React from 'react'
+
+export default function App() {
+  return <div/>
+}


### PR DESCRIPTION
  - Remove `oct-head-margin` in favor of straight CSS to accomplish same
  - Render existing header and footer content for legacy pages only
  - Render blank v2 app at `/v2/wildfirecheck`
  - Start being explicit about file extensions, which will allow JS and
    JSX files to be differentiated programmatically because they will
    inevitably require slightly different treatment (e.g., when linting)