### PR TITLE
client: Fix pagination scrolling behavior

### DIFF
--- a/src/v2/components/Fire.jsx
+++ b/src/v2/components/Fire.jsx
@@ -71,17 +71,17 @@ export default function Fire(props) {
 
   useEffect(() => {
     // Handle scrolling events while this fire is active as long as we’re not
-    // scrolling to it automatically.
-    if (selected && scrollingTo === null) {
+    // scrolling to it or another fire automatically.
+    if (selected && scrollToIndex < 0) {
       const {current: container} = containerRef
       const {bottom, height, top} = container.getBoundingClientRect()
 
       if (bottom - height / 4 <= scrollTopThreshold) {
-        // When this fire scrolls off the top of the page (underneath and fully
+        // When this fire scrolls off the top of the page (underneath and 3/4
         // occluded by the toolbar), pass control to the next fire.
         onSelectFire(index + 1)
       } else if (top + height / 4 >= scrollTopThreshold + height) {
-        // When this fire scrolls more than its own height away from the top of
+        // When this fire scrolls more than 3/4 its own height from the top of
         // the page (i.e., from the toolbar), pass control to the previous fire.
         onSelectFire(index - 1)
       }
@@ -108,7 +108,7 @@ export default function Fire(props) {
       })
     }
   }, [
-    index, onSelectFire, selected, scrollBottomThreshold, scrollingTo,
+    index, onSelectFire, selected, scrollBottomThreshold, scrollToIndex,
     scrollTopThreshold, scrollTop, shouldLoadVideo
   ])
 


### PR DESCRIPTION
Prior to these changes, pagination and scrolling sometimes got stuck. A
user could page forward one fire, page back, page forward again, and
finally page back. Paging back the first time scrolled to the expected
position. But the second time did not. Similarly, there were times when
the paged-to fire wouldn’t be selected at all.

Fixed by ignoring scroll events when _any_ fire is being scrolled into
view automatically.