### PR TITLE
client: Implement multiple camera angles per fire event

### DIFF
--- a/src/v2/components/FireList.jsx
+++ b/src/v2/components/FireList.jsx
@@ -20,6 +20,7 @@ import FireListContent from './FireListContent.jsx'
 import FireListControl from './FireListControl.jsx'
 
 import debounce from '../modules/debounce.mjs'
+import getCameraKey from '../modules/getCameraKey.mjs'
 
 /**
  * Receives a list of `fires` from a higher-order component and is responsible
@@ -70,8 +71,9 @@ export default function FireList(props) {
     if (index > -1 && index < nFires && index !== selectedIndex) {
       setSelectedIndex(index)
       setScrollToIndex(-1)
+      console.log('selected:', index + 1, getCameraKey(fires[index]), fires[index]._anglesByKey != null ? Object.keys(fires[index]._anglesByKey).join(', ') : '')
     }
-  }, [nFires, selectedIndex])
+  }, [fires, nFires, selectedIndex])
 
   /**
    * Cues a lower-order component to initiate scrolling to the fire at `index`

--- a/src/v2/components/FireList.jsx
+++ b/src/v2/components/FireList.jsx
@@ -20,7 +20,6 @@ import FireListContent from './FireListContent.jsx'
 import FireListControl from './FireListControl.jsx'
 
 import debounce from '../modules/debounce.mjs'
-import getCameraKey from '../modules/getCameraKey.mjs'
 
 /**
  * Receives a list of `fires` from a higher-order component and is responsible
@@ -29,6 +28,7 @@ import getCameraKey from '../modules/getCameraKey.mjs'
  *
  * @param {Object} props
  * @param {Array} props.fires - A list of fires to be shown to the user.
+ * @param {Array} props.firesByKey - An index of all known fires.
  * @param {number} props.indexOfOldFires - The index in `props.fires` where old
  *     fires begin (-1 if `props.fires` doesn’t currently contain older fires).
  * @param {number} props.nOldFires - The total number of old fires, regardless
@@ -38,7 +38,9 @@ import getCameraKey from '../modules/getCameraKey.mjs'
  * @returns {React.Element}
  */
 export default function FireList(props) {
-  const {fires, indexOfOldFires, nOldFires, onToggleAllFires} = props
+  const {
+    fires, firesByKey, indexOfOldFires, nOldFires, onToggleAllFires
+  } = props
 
   // The top position at which DOM elements become either visible or occluded
   // by the voting and pagination toolbar while scrolling.
@@ -71,9 +73,8 @@ export default function FireList(props) {
     if (index > -1 && index < nFires && index !== selectedIndex) {
       setSelectedIndex(index)
       setScrollToIndex(-1)
-      console.log('selected:', index + 1, getCameraKey(fires[index]), fires[index]._anglesByKey != null ? Object.keys(fires[index]._anglesByKey).join(', ') : '')
     }
-  }, [fires, nFires, selectedIndex])
+  }, [nFires, selectedIndex])
 
   /**
    * Cues a lower-order component to initiate scrolling to the fire at `index`
@@ -148,6 +149,7 @@ export default function FireList(props) {
     },
     FIRE_LIST_CONTROL: {
       fires,
+      firesByKey,
       indexOfOldFires,
       onScrollToFire: handleScrollToFire,
       onSelectFire: handleSelectFire,

--- a/src/v2/components/FireListMap.jsx
+++ b/src/v2/components/FireListMap.jsx
@@ -24,8 +24,6 @@ import getCameraKey from '../modules/getCameraKey.mjs'
 import findPrimaryPolygon from '../modules/findPrimaryPolygon.mjs'
 import hasCameraKey from '../modules/hasCameraKey.mjs'
 
-const {log: println} = console
-
 const Props = {
   BOUNDS: [[32.4, -122.1], [36.9, -115.8]], // Corners of `midsocalCams` region.
   CENTER: [34.69, 240.96], // Midpoint between corners of `BOUNDS`.
@@ -247,7 +245,7 @@ export default function FireMap(props) {
 
 function addPolygon(fire, polygons, greatPolygon) {
   const {L} = window
-  const p = getBestPolygon(fire)
+  const p = findPrimaryPolygon(fire)
 
   // NOTE: Points passed when creating a polygon shouldn’t have a last
   // point equal to the first one. It’s better to filter out such points.
@@ -257,16 +255,6 @@ function addPolygon(fire, polygons, greatPolygon) {
   greatPolygon.splice(greatPolygon.length, 0, ...vertices)
 
   polygons.push(L.polygon(vertices, Props.PRIMARY_POLYGON))
-}
-
-function getBestPolygon(fire) {
-  try {
-    return findPrimaryPolygon(fire)
-  } catch (error) {
-    println(error)
-    println('Falling back to fire.polygon')
-    return fire.polygon
-  }
 }
 
 function initializeMap(mapRef, timerRef) {

--- a/src/v2/components/FireListMap.jsx
+++ b/src/v2/components/FireListMap.jsx
@@ -213,11 +213,7 @@ export default function FireMap(props) {
             markers[key].polygons.forEach((p, _, a) => {
               const {lat, lng} = p.getLatLngs()[0][0]
 
-              // XXX: As observed, some fire events include polygons that do not
-              // begin at the same latitude and longitude as the camera itself.
-              // In these cases, there’s only a single polygon so we use it as
-              // the primary one...
-              if ((coordinates[0] === lat && coordinates[1] === lng) || a.length === 1) {
+              if (coordinates[0] === lat && coordinates[1] === lng) {
                 p.setStyle(Props.PRIMARY_POLYGON)
                 p.bringToFront()
               } else {

--- a/src/v2/components/FireListMap.jsx
+++ b/src/v2/components/FireListMap.jsx
@@ -21,7 +21,10 @@ import Duration from '../modules/Duration.mjs'
 import CameraMarker from './CameraMarker.jsx'
 
 import getCameraKey from '../modules/getCameraKey.mjs'
+import findPrimaryPolygon from '../modules/findPrimaryPolygon.mjs'
 import hasCameraKey from '../modules/hasCameraKey.mjs'
+
+const {log: println} = console
 
 const Props = {
   BOUNDS: [[32.4, -122.1], [36.9, -115.8]], // Corners of `midsocalCams` region.
@@ -39,7 +42,7 @@ const Props = {
     opacity: 0.33,
     weight: 1.50
   },
-  POV_POLYGON: {
+  PRIMARY_POLYGON: {
     color: '#f0f',
     dashArray: null,
     fill: '#f0f',
@@ -60,15 +63,16 @@ const Props = {
  * Provides an interactive map of detected fires.
  *
  * @param {Object} props
- * @param {Array} fires - The list of fires to plot on the map.
- * @param {function(number)} onScrollToFire - Event handler to be called when
+ * @param {Array} props.fires - The list of fires to plot on the map.
+ * @param {Array} props.firesByKey - An index of all fires.
+ * @param {function(number)} props.onScrollToFire - Event handler to be called
  *     when a fire at a specific index should scroll itself into view.
  * @param {number} props.selectedIndex - The index of the active fire.
  *
  * @returns {React.Element}
  */
 export default function FireMap(props) {
-  const {fires, onScrollToFire, selectedIndex} = props
+  const {fires, firesByKey, onScrollToFire, selectedIndex} = props
 
   const [scrollingTo, setScrollingTo] = useState(-1)
 
@@ -142,16 +146,14 @@ export default function FireMap(props) {
       const cameraMarker = L.divIcon({html})
 
       const greatPolygon = []
-      const polygons = sourcePolygons.map((p) => {
-        // NOTE: Points passed when creating a polygon shouldn’t have a last
-        // point equal to the first one. It’s better to filter out such points.
-        // https://leafletjs.com/reference.html#polygon
-        const vertices = p.slice(0, p.length - 1)
+      const polygons = []
 
-        greatPolygon.splice(greatPolygon.length, 0, ...vertices)
+      // Generate polygons for each secondary angle on this fire.
+      Object.keys(x._anglesByKey).forEach((k) =>
+        addPolygon(firesByKey[k], polygons, greatPolygon))
 
-        return L.polygon(vertices, Props.POLYGON)
-      })
+      // Generate a polygon for this fire’s primary angle.
+      addPolygon(x, polygons, greatPolygon)
 
       markers[key] = {
         coordinates,
@@ -167,7 +169,7 @@ export default function FireMap(props) {
 
       markers[key].icon.addTo(map)
     })
-  }, [fires, handleCameraClick])
+  }, [fires, firesByKey, handleCameraClick])
 
   useEffect(() => {
     // `selectedIndex` will change rapidly when fires are loading, once for each
@@ -202,11 +204,23 @@ export default function FireMap(props) {
             markers[key].icon.remove()
             markers[key].icon.addTo(map)
 
-            markers[key].polygons.forEach((p) => {
+            Object.keys(fire._anglesByKey).forEach((k) => {
+              if (markers[k] != null) {
+                // XXX: Force icon to front.
+                markers[k].icon.remove()
+                markers[k].icon.addTo(map)
+              }
+            })
+
+            markers[key].polygons.forEach((p, _, a) => {
               const {lat, lng} = p.getLatLngs()[0][0]
 
-              if (coordinates[0] === lat && coordinates[1] === lng) {
-                p.setStyle(Props.POV_POLYGON)
+              // XXX: As observed, some fire events include polygons that do not
+              // begin at the same latitude and longitude as the camera itself.
+              // In these cases, there’s only a single polygon so we use it as
+              // the primary one...
+              if ((coordinates[0] === lat && coordinates[1] === lng) || a.length === 1) {
+                p.setStyle(Props.PRIMARY_POLYGON)
                 p.bringToFront()
               } else {
                 p.setStyle(Props.POLYGON)
@@ -230,6 +244,30 @@ export default function FireMap(props) {
 }
 
 // -----------------------------------------------------------------------------
+
+function addPolygon(fire, polygons, greatPolygon) {
+  const {L} = window
+  const p = getBestPolygon(fire)
+
+  // NOTE: Points passed when creating a polygon shouldn’t have a last
+  // point equal to the first one. It’s better to filter out such points.
+  // https://leafletjs.com/reference.html#polygon
+  const vertices = p.slice(0, p.length - 1)
+
+  greatPolygon.splice(greatPolygon.length, 0, ...vertices)
+
+  polygons.push(L.polygon(vertices, Props.PRIMARY_POLYGON))
+}
+
+function getBestPolygon(fire) {
+  try {
+    return findPrimaryPolygon(fire)
+  } catch (error) {
+    println(error)
+    println('Falling back to fire.polygon')
+    return fire.polygon
+  }
+}
 
 function initializeMap(mapRef, timerRef) {
   if (mapRef.current == null) {

--- a/src/v2/components/FireListMap.jsx
+++ b/src/v2/components/FireListMap.jsx
@@ -210,10 +210,13 @@ export default function FireMap(props) {
               }
             })
 
-            markers[key].polygons.forEach((p, _, a) => {
-              const {lat, lng} = p.getLatLngs()[0][0]
+            markers[key].polygons.forEach((p) => {
+              // Search polygon `p` for coordinates at the same latitude and
+              // longitude as the camera itself.
+              const isPrimary = p.getLatLngs()[0].some(({lat, lng}) =>
+                lat === coordinates[0] && lng === coordinates[1])
 
-              if (coordinates[0] === lat && coordinates[1] === lng) {
+              if (isPrimary) {
                 p.setStyle(Props.PRIMARY_POLYGON)
                 p.bringToFront()
               } else {

--- a/src/v2/components/PotentialFireList.jsx
+++ b/src/v2/components/PotentialFireList.jsx
@@ -104,14 +104,15 @@ export default function PotentialFireList() {
     } else {
       firesByKey[key] = fire
 
+      allFires.forEach((x) => {
+        // XXX: Check both directions because fire events are not guaranteed to
+        // arrive in order so `x` might be a subset of `fire`, or vice versa.
+        hasAngleOfFire(x, fire)
+        hasAngleOfFire(fire, x)
+      })
+
       allFires.unshift(fire)
       allFires.sort((a, b) => b.sortId - a.sortId)
-
-      allFires.forEach((a) => {
-        allFires.forEach((b) => {
-          hasAngleOfFire(a, b)
-        })
-      })
 
       updateFires(includesAllFires)
     }

--- a/src/v2/components/PotentialFireList.jsx
+++ b/src/v2/components/PotentialFireList.jsx
@@ -102,12 +102,14 @@ export default function PotentialFireList() {
         console.error('Not implemented: updateFires()')
       }
     } else {
-      allFires.forEach((x) => {
-        hasAngleOfFire(x, fire)
-      })
-
       allFires.unshift(fire)
       allFires.sort((a, b) => b.sortId - a.sortId)
+
+      allFires.forEach((a) => {
+        allFires.forEach((b) => {
+          hasAngleOfFire(a, b)
+        })
+      })
 
       updateFires(includesAllFires)
     }

--- a/src/v2/components/PotentialFireList.jsx
+++ b/src/v2/components/PotentialFireList.jsx
@@ -33,6 +33,7 @@ import Duration from '../modules/Duration.mjs'
 
 import getCameraKey from '../modules/getCameraKey.mjs'
 import getEventSource from '../modules/getEventSource.mjs'
+import hasAngleOfFire from '../modules/hasAngleOfFire.mjs'
 import hasCameraKey from '../modules/hasCameraKey.mjs'
 
 import FireList from './FireList.jsx'
@@ -101,8 +102,13 @@ export default function PotentialFireList() {
         console.error('Not implemented: updateFires()')
       }
     } else {
+      allFires.forEach((x) => {
+        hasAngleOfFire(x, fire)
+      })
+
       allFires.unshift(fire)
       allFires.sort((a, b) => b.sortId - a.sortId)
+
       updateFires(includesAllFires)
     }
   }, [includesAllFires, updateFires])

--- a/src/v2/components/PotentialFireList.jsx
+++ b/src/v2/components/PotentialFireList.jsx
@@ -34,7 +34,6 @@ import Duration from '../modules/Duration.mjs'
 import getCameraKey from '../modules/getCameraKey.mjs'
 import getEventSource from '../modules/getEventSource.mjs'
 import hasAngleOfFire from '../modules/hasAngleOfFire.mjs'
-import hasCameraKey from '../modules/hasCameraKey.mjs'
 
 import FireList from './FireList.jsx'
 
@@ -55,6 +54,7 @@ export default function PotentialFireList() {
 
   const allFiresRef = useRef([])
   const eventSourceRef = useRef()
+  const firesByKeyRef = useRef({})
   const sseVersionRef = useRef()
 
   const updateFires = useCallback((shouldIncludeAllFires) => {
@@ -91,17 +91,19 @@ export default function PotentialFireList() {
     }
 
     const {current: allFires} = allFiresRef
+    const {current: firesByKey} = firesByKeyRef
     const key = getCameraKey(fire)
-    const existingFire = allFires.find((x) => hasCameraKey(x, key))
 
-    if (existingFire != null) {
-      if (existingFire.croppedUrl !== croppedUrl) {
+    if (firesByKey[key] != null) {
+      if (firesByKey[key].croppedUrl !== croppedUrl) {
         // Fire is already indexed, but its video has been updated.
-        existingFire.croppedUrl = croppedUrl
+        firesByKey[key].croppedUrl = croppedUrl
         // TODO: Update video source, reload video.
         console.error('Not implemented: updateFires()')
       }
     } else {
+      firesByKey[key] = fire
+
       allFires.unshift(fire)
       allFires.sort((a, b) => b.sortId - a.sortId)
 
@@ -135,6 +137,7 @@ export default function PotentialFireList() {
 
   return <FireList
     fires={fires}
+    firesByKey={firesByKeyRef.current}
     indexOfOldFires={includesAllFires ? indexOfOldFires : -1}
     nOldFires={indexOfOldFires > -1 ? allFiresRef.current.length - indexOfOldFires : 0}
     onToggleAllFires={handleToggleAllFires}/>

--- a/src/v2/components/PotentialFireList.jsx
+++ b/src/v2/components/PotentialFireList.jsx
@@ -102,15 +102,9 @@ export default function PotentialFireList() {
         console.error('Not implemented: updateFires()')
       }
     } else {
+      allFires.forEach((x) => hasAngleOfFire(x, fire))
+
       firesByKey[key] = fire
-
-      allFires.forEach((x) => {
-        // XXX: Check both directions because fire events are not guaranteed to
-        // arrive in order so `x` might be a subset of `fire`, or vice versa.
-        hasAngleOfFire(x, fire)
-        hasAngleOfFire(fire, x)
-      })
-
       allFires.unshift(fire)
       allFires.sort((a, b) => b.sortId - a.sortId)
 

--- a/src/v2/modules/arePolygonsEqual.mjs
+++ b/src/v2/modules/arePolygonsEqual.mjs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------------
+// Copyright 2022 Open Climate Tech Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+export default function arePolygonsEqual(a, b) {
+  if (a == null || b == null || a.length !== b.length) {
+    return false
+  }
+
+  for (let i = 0, n = a.length; i < n; ++i) {
+    if (a[i][0] !== b[i][0] || a[i][1] !== b[i][1]) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/src/v2/modules/findPrimaryPolygon.mjs
+++ b/src/v2/modules/findPrimaryPolygon.mjs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // -----------------------------------------------------------------------------
 
-import getCameraKey from './getCameraKey.mjs'
-
 /**
  * Finds the polygon in `fire`’s polygon camera angles that originates at the
  * same coordinates as the fire event itself.
@@ -27,14 +25,6 @@ import getCameraKey from './getCameraKey.mjs'
  * @throws {Error} If a such a polygon isn’t found.
  */
 export default function findPrimaryPolygon(fire) {
-  const {camInfo: {latitude, longitude}, sourcePolygons} = fire
-
-  for (let i = sourcePolygons.length - 1; i > -1; --i) {
-    const polygon = sourcePolygons[i]
-    if (polygon[0][0] === latitude && polygon[0][1] === longitude) {
-      return polygon
-    }
-  }
-
-  throw new Error(`Expected to find primary polygon for ${getCameraKey(fire)} starting at ${latitude}, ${longitude}`)
+  const {sourcePolygons} = fire
+  return sourcePolygons[sourcePolygons.length - 1]
 }

--- a/src/v2/modules/findPrimaryPolygon.mjs
+++ b/src/v2/modules/findPrimaryPolygon.mjs
@@ -21,8 +21,6 @@
  * @param {Object} fire - The fire event to inspect.
  *
  * @returns {Array} The polygon originating at the fire event’s coordinates.
- *
- * @throws {Error} If a such a polygon isn’t found.
  */
 export default function findPrimaryPolygon(fire) {
   const {sourcePolygons} = fire

--- a/src/v2/modules/findPrimaryPolygon.mjs
+++ b/src/v2/modules/findPrimaryPolygon.mjs
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------------
+// Copyright 2022 Open Climate Tech Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+import getCameraKey from './getCameraKey.mjs'
+
+/**
+ * Finds the polygon in `fire`’s polygon camera angles that originates at the
+ * same coordinates as the fire event itself.
+ *
+ * @param {Object} fire - The fire event to inspect.
+ *
+ * @returns {Array} The polygon originating at the fire event’s coordinates.
+ *
+ * @throws {Error} If a such a polygon isn’t found.
+ */
+export default function findPrimaryPolygon(fire) {
+  const {camInfo: {latitude, longitude}, sourcePolygons} = fire
+
+  for (let i = sourcePolygons.length - 1; i > -1; --i) {
+    const polygon = sourcePolygons[i]
+    if (polygon[0][0] === latitude && polygon[0][1] === longitude) {
+      return polygon
+    }
+  }
+
+  throw new Error(`Expected to find primary polygon for ${getCameraKey(fire)} starting at ${latitude}, ${longitude}`)
+}

--- a/src/v2/modules/hasAngleOfFire.mjs
+++ b/src/v2/modules/hasAngleOfFire.mjs
@@ -21,8 +21,18 @@ import getCameraKey from './getCameraKey.mjs'
 
 const TIMESTAMP_LIMIT_SECONDS = 15 * Duration.MINUTE / Duration.SECOND
 
-let count = 0
-
+/**
+ * Determines whether the polygon camera angles of `candidate` are a strict
+ * subset of `fire`; each overlapping fire event will be annotated with an
+ * `_anglesByKey` property indexing its related secondary events.
+ *
+ * @param {Object} candidate - A fire event to be inspected to find out if it
+ *     overlaps with `fire`.
+ * @param {Object} fire - A fire event that might overlap with `candidate`.
+ *
+ * @returns {boolean} `true` if `candidate` polygons are a subset of `fire`
+ *     polygons; otherwise, `false`.
+ */
 export default function hasAngleOfFire(candidate, fire) {
   const key = getCameraKey(candidate)
 
@@ -48,10 +58,6 @@ export default function hasAngleOfFire(candidate, fire) {
           }
         }
       }
-    }
-
-    if  (fire._anglesByKey[key] === true) {
-      console.log(key, getCameraKey(fire))
     }
   }
 

--- a/src/v2/modules/hasAngleOfFire.mjs
+++ b/src/v2/modules/hasAngleOfFire.mjs
@@ -1,0 +1,59 @@
+// -----------------------------------------------------------------------------
+// Copyright 2022 Open Climate Tech Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+import Duration from './Duration.mjs'
+
+import arePolygonsEqual from './arePolygonsEqual.mjs'
+import getCameraKey from './getCameraKey.mjs'
+
+const TIMESTAMP_LIMIT_SECONDS = 15 * Duration.MINUTE / Duration.SECOND
+
+let count = 0
+
+export default function hasAngleOfFire(candidate, fire) {
+  const key = getCameraKey(candidate)
+
+  if (candidate._anglesByKey == null) {
+    candidate._anglesByKey = {}
+  }
+
+  if (fire._anglesByKey == null) {
+    fire._anglesByKey = {}
+  }
+
+  if (candidate !== fire && fire._anglesByKey[key] !== true) {
+    if (candidate.sourcePolygons.length < fire.sourcePolygons.length) {
+      if (candidate.timestamp <= fire.timestamp) {
+        if (candidate.timestamp >= fire.timestamp - TIMESTAMP_LIMIT_SECONDS) {
+          const found = candidate.sourcePolygons.every((a) => {
+            return fire.sourcePolygons.find((b) => arePolygonsEqual(a, b))
+          })
+
+          if (found === true) {
+            candidate._anglesByKey[getCameraKey(fire)] = true
+            fire._anglesByKey[key] = true
+          }
+        }
+      }
+    }
+
+    if  (fire._anglesByKey[key] === true) {
+      console.log(key, getCameraKey(fire))
+    }
+  }
+
+  return fire._anglesByKey[key] === true
+}

--- a/test/v2/modules/arePolygonsEqual.test.mjs
+++ b/test/v2/modules/arePolygonsEqual.test.mjs
@@ -1,0 +1,76 @@
+// -----------------------------------------------------------------------------
+// Copyright 2022 Open Climate Tech Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+import {expect} from 'chai'
+
+import arePolygonsEqual from '../../../src/v2/modules/arePolygonsEqual.mjs'
+
+describe('arePolygonsEqual()', () => {
+  it('should be equal', () => {
+    const a = [
+      [32.8403, -117.249],
+      [33.37490391451302, -116.97660570015627],
+      [33.42492203887114, -117.11402936739367],
+      [32.8403, -117.249]
+    ]
+
+    const b = [
+      [32.8403, -117.249],
+      [33.37490391451302, -116.97660570015627],
+      [33.42492203887114, -117.11402936739367],
+      [32.8403, -117.249]
+    ]
+
+    expect(arePolygonsEqual(a, b)).to.be.true
+  })
+
+  it('should not be equal (vertex coordinates)', () => {
+    const a = [
+      [32.8403, -117.249],
+      [33.37490391451301, -116.97660570015627],
+      [33.42492203887114, -117.11402936739367],
+      [32.8403, -117.249]
+    ]
+
+    const b = [
+      [32.8403, -117.249],
+      [33.37490391451302, -116.97660570015627],
+      [33.42492203887114, -117.11402936739367],
+      [32.8403, -117.249]
+    ]
+
+    expect(arePolygonsEqual(a, b)).to.be.false
+  })
+
+  it('should not be equal (n vertices)', () => {
+    const a = [
+      [32.8403, -117.249],
+      [33.37490391451302, -116.97660570015627],
+      [33.42492203887114, -117.11402936739367],
+      [32.8403, -117.249]
+    ]
+
+    const b = [
+      [32.8403, -117.249],
+      [33.37490391451302, -116.97660570015627],
+      [33.37490391451302, -116.97660570015627],
+      [33.42492203887114, -117.11402936739367],
+      [32.8403, -117.249]
+    ]
+
+    expect(arePolygonsEqual(a, b)).to.be.false
+  })
+})


### PR DESCRIPTION
  - Index incoming fire events by camera ID/timestamp in a lookup table
  - Add `._anglesByKey` property to incoming fire events
  - Populate `._anglesByKey` with camera angles that overlap the given
    fire event within the last 15 minutes
  - Bring camera markers corresponding to secondary angles to the front
    z-Index of the map to facilitate angle selection by clicking markers