### PR TITLE
client: Clear event source once on close

### DIFF
--- a/src/v2/components/FireListMap.jsx
+++ b/src/v2/components/FireListMap.jsx
@@ -124,11 +124,23 @@ export default function FireMap(props) {
     // Generate map objects (markers, polygons, ...) once whenever the list of
     // fires changes as opposed to each time the user activates a given fire.
 
-    // Start by clearing all cached markers.
+    // Start by clearing all cached markers...
     Object.keys(markersRef.current).forEach((key) => {
       const marker = markersRef.current[key]
       marker.icon.remove()
       marker.polygons.forEach((x) => x.remove())
+
+      if (marker.intersection != null) {
+        marker.intersection.remove()
+      }
+    })
+
+    // ...and all cached stacks.
+    Object.keys(stacksRef.current).forEach((key) => {
+      const stack = stacksRef.current[key]
+      if (stack.badge != null) {
+        stack.badge.remove()
+      }
     })
 
     const {L} = window
@@ -330,11 +342,6 @@ export default function FireMap(props) {
             })
 
             if (markers[key].intersection != null) {
-              // BUG: Somehow `intersection` is not removed during development
-              // with Webpack Hot Module Replacement. The intersecting polygon
-              // is rendered multiple times, and the only way to clear all such
-              // instances is to reload the page.
-              markers[key].intersection.remove()
               markers[key].intersection.addTo(map)
             }
 


### PR DESCRIPTION
Prior to this change, the event source was closed, recreated, and its
fire events reprocessed any time the list of fires changed, including
when toggling older fires. With this change, one event source remains
cached until it is closed (e.g., when the page is unloaded).